### PR TITLE
Use dotenv

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+ROCKETFUEL_API_SANDBOX_AUTH_TOKEN: 'rocketfuel-api-sandbox-auth-token'

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,7 @@
 /spec/reports/
 /tmp/
 
+.env.test
+
 # rspec failure tracking
 .rspec_status

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ connection = RocketfuelApi::Connection.new(
 
 # for production
 connection = RocketfuelApi::Connection.new(
-  uri: 'https://api.rocketfuel.com/2016'
+  uri: 'https://api.rocketfuel.com/2016',
   auth_token: ENV['ROCKETFUEL_API_AUTH_TOKEN']
 )
 
@@ -43,9 +43,12 @@ Note: Only the `Company` Service `GET` requests are tested so far.
 
 ## Development
 
-To be able to run the specs, the env var `ROCKETFUEL_API_SANDBOX_AUTH_TOKEN` is needed.
+Run specs with `bundle exec rspec`.
 
-We run rake rubocop to make sure, everything looks good.
+To recreate or create new VCR episodes, a proper value for env var `ROCKETFUEL_API_SANDBOX_AUTH_TOKEN` is needed.
+We recommend that you set it in `.env.test` file. 
+
+We run `rake rubocop` to make sure, everything looks good.
 
 ## License
 

--- a/rocketfuel_api.gemspec
+++ b/rocketfuel_api.gemspec
@@ -32,4 +32,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'vcr'
   spec.add_development_dependency 'webmock'
+  spec.add_development_dependency 'dotenv'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'dotenv'
+Dotenv.load('.env.test', '.env')
+
 require 'bundler/setup'
 require 'rocketfuel_api'
 require 'vcr'


### PR DESCRIPTION
We don't need to have a real value for ROCKETFUEL_API_SANDBOX_AUTH_TOKEN to be able to run specs, only when recording new VCR episodes.